### PR TITLE
fix: remove setuptools limitation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,14 +9,14 @@ source:
   sha256: 20b43c660e48ed47f433bce5873a2a3d4b9b6a7ba47bd7f7d2a7cec4bec5551f
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - python >=3.6
-    - setuptools <58  # because of https://github.com/jenisys/parse_type/issues/17
+    - setuptools
     - pip
   run:
     - python >=3.6


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Fixed limitation to setuptools version, which was fixed with 0.6.0 